### PR TITLE
Fix profile scripts

### DIFF
--- a/profiles/tailscale
+++ b/profiles/tailscale
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Install tailscale
 
-set -eu
+set -u
 
 if [ ! -e /etc/yum.repos.d/tailscale.repo ]; then
     echo "Installing repo..."

--- a/profiles/vscode
+++ b/profiles/vscode
@@ -2,7 +2,7 @@
 # Install vscode as an overlay so it can access the host terminal
 # This is hopefully a temporary workaround until the flatpak can
 # access the system/toolbox environments without ugly hacks.
-set -eu
+set -u
 
 # Disclaimer
 echo "This profile will remove the VSCode flatpak in favor of an overlayed package, in order to enable access to the host terminal. This is a temporary workaround until the flatpak can access the system/toolbox environment without ugly hacks."

--- a/profiles/yaru
+++ b/profiles/yaru
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install the Yaru theme
-set -eu
+set -u
 
 
 # Check if yaru-theme is already installed

--- a/profiles/yaru-dark
+++ b/profiles/yaru-dark
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install the Yaru (dark) theme
-set -eu
+set -u
 
 rpm -q yaru-theme > /dev/null
 if [ $? -eq 1 ]; then


### PR DESCRIPTION
Change `set -eu` to `set u` because `e` causes the script to fail upon an error. I'm checking the return code of the failing commands, so I know if a package is installed, for example, so no need to abort prematurely.