### PR TITLE
Remove invalid repos before bailing

### DIFF
--- a/bits/common
+++ b/bits/common
@@ -29,7 +29,8 @@ flatpak_install_remote () {
 
     # Verify that the remote is setup
     if [ ! -f "/var/lib/flatpak/repo/$1.trustedkeys.gpg" ]; then
-        echo "Unable to verify public key"
+        flatpak remote-delete $1
+        echo "Unable to verify public key. Please try again."
         return 1
     fi
     return 0


### PR DESCRIPTION
If a flatpak repo is missing its GPG key, remove the repo before bailing, so that the next run of the script will re-install the repo with a GPG key.

This fixes issue #25.