### PR TITLE
Better default apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ I have selected a default set of apps that I use that I notice lots of other peo
   - Work apps -  zoom, slack, standard notes, signal, riot, mailspring
   - Fun apps - discord and Steam (Last release of flatpak fixed many of Steam's issues, it works much better now, try it)
   - A selection of browsers - Firefox, Brave, Chrome, Edge
+  - The excellent [Extensions Manager](https://www.omgubuntu.co.uk/2022/01/gnome-extension-manager-app-easy-install) application is included to manage your GNOME extensions. Note that extensions.gnome.org won't work due to sandboxing, so this is a work around until all that is sorted in the future.
 
 I replaced the distro Firefox with the flatpak from upstream.
 As per upstream Silverblue, you want your apps to be either in containers (where you install them via apt/dnf) and your desktop apps to come via flatpaks. 

--- a/applications.list
+++ b/applications.list
@@ -1,7 +1,6 @@
 # Default-y apps
 #
 org.gnome.Dejadup
-org.gnome.Extensions
 org.gnome.Rhythmbox3
 org.gnome.Shotwell
 org.gustavoperedo.FontDownloader

--- a/applications.list
+++ b/applications.list
@@ -9,13 +9,17 @@ org.libreoffice.LibreOffice
 org.mozilla.firefox
 org.mozilla.Thunderbird
 org.freedesktop.Platform.ffmpeg-full/x86_64/21.08
+io.github.celluloid_player.Celluloid
+com.github.tchx84.Flatseal
+com.mattjakeman.ExtensionManager
+org.gnome.FileRoller
+org.gnome.Firmware
 
 # Other goodies
 #
 #com.belmoussaoui.Obfuscate
 #com.discordapp.Discord
 #com.getmailspring.Mailspring
-#com.github.tchx84.Flatseal
 #com.obsproject.Studio
 #com.slack.Slack
 #com.spotify.Client


### PR DESCRIPTION
Ok now that we have lived on this setup I'm making some convenience changes:

- We need flatseal to manage flatpaks so just adding it. 
- File roller isn't included by default in fedora so adding that.
- Firmware is a nice GUI for fwupd and useful.
- Celluloid is based on mpv but fits nicer on the default desktop, it's playing everything I've thrown at it so good default.
- And the big one is extension manager, that looks like the stock extensions app but additionally allows search, download, and installation right from it's UI and since we can't use extensions.gnome.org right now it's a must-have. Swapping it out. 

PTAL @AdamIsrael and @marcoceppi 