### PR TITLE
bits: fix gnome-terminal profile generator, Fix #35

### DIFF
--- a/bits/distrobox-terminal-profile.sh
+++ b/bits/distrobox-terminal-profile.sh
@@ -78,6 +78,16 @@ PROFILE_UUID=$(cat /proc/sys/kernel/random/uuid)
 
 # Gemerate the dconf file for terminal profile
 DCONF_PROFILE=$(dconf dump /org/gnome/terminal/legacy/profiles:/)
+
+if ! echo "$DCONF_PROFILE" | grep 'list='; then
+	DCONF_PROFILE="
+[/]
+list=['b1dcc9dd-5262-4d8d-a863-c897e6d979b9']
+
+$DCONF_PROFILE
+"
+fi
+
 DCONF_PROFILE=$(echo "$DCONF_PROFILE" | sed "s|list=\[|list=\['$PROFILE_UUID',|g")
 DCONF_PROFILE="$DCONF_PROFILE
 


### PR DESCRIPTION
Right now, a clean install (or a `dconf reset`) of the gnome-terminal
has a completely empty dconf configuration.

Adding the profile works, but the terminal won't recognize new profiles
if there isn't a `list` attribute with all the UUIDs of the profiles.

Also the `Unnamed Profile` has a fixed UUID
`b1dcc9dd-5262-4d8d-a863-c897e6d979b9`, so we must include that or it
won't work...

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>